### PR TITLE
Allow usage of short assertion types

### DIFF
--- a/src/Entities/Assertions/AssertionFactory.php
+++ b/src/Entities/Assertions/AssertionFactory.php
@@ -341,6 +341,7 @@ class AssertionFactory
 
     /**
      * Tries to create assertion of $assertionType
+     *
      * @param string $assertionType the assertion type
      * @param string $constraint    the constraint to validate
      * @return null|AssertionInterface
@@ -375,6 +376,7 @@ class AssertionFactory
     /**
      * Resolves and returns the fully qualified namespace of $assertionType
      * or null if $assertionType cannot be resolved to an accessible class
+     *
      * @param string $assertionType the assertion type
      * @return null|string
      */
@@ -405,6 +407,7 @@ class AssertionFactory
     /**
      * Iterates through the 'use' operators of the current structure and
      * returns the fully qualified namespace to the Assertion or null if none is found
+     *
      * @param string $assertionType the assertion type
      * @return null|string
      */
@@ -434,6 +437,8 @@ class AssertionFactory
     }
 
     /**
+     * Sets the instance of the current definition
+     *
      * @param StructureDefinitionInterface $currentDefinition the definition of the current structure
      * @return void
      */
@@ -443,6 +448,8 @@ class AssertionFactory
     }
 
     /**
+     * Returns the instance of the current definition
+     *
      * @return null|StructureDefinitionInterface
      */
     public function getCurrentDefinition()

--- a/src/Entities/Assertions/AssertionFactory.php
+++ b/src/Entities/Assertions/AssertionFactory.php
@@ -79,7 +79,7 @@ class AssertionFactory
     /**
      * The definition of the structure we are currently iterating through
      *
-     * @var StructureDefinitionInterface
+     * @var StructureDefinitionInterface $currentDefinition
      */
     protected $currentDefinition;
 
@@ -344,6 +344,7 @@ class AssertionFactory
      *
      * @param string $assertionType the assertion type
      * @param string $constraint    the constraint to validate
+     *
      * @return null|AssertionInterface
      * @throws \Exception
      */
@@ -378,6 +379,7 @@ class AssertionFactory
      * or null if $assertionType cannot be resolved to an accessible class
      *
      * @param string $assertionType the assertion type
+     *
      * @return null|string
      */
     protected function getAssertionClassPath($assertionType)
@@ -409,6 +411,7 @@ class AssertionFactory
      * returns the fully qualified namespace to the Assertion or null if none is found
      *
      * @param string $assertionType the assertion type
+     *
      * @return null|string
      */
     protected function resolveUsedAssertionStructure($assertionType)
@@ -440,6 +443,7 @@ class AssertionFactory
      * Sets the instance of the current definition
      *
      * @param StructureDefinitionInterface $currentDefinition the definition of the current structure
+     *
      * @return void
      */
     public function setCurrentDefinition(StructureDefinitionInterface $currentDefinition)

--- a/src/Entities/Assertions/AssertionFactory.php
+++ b/src/Entities/Assertions/AssertionFactory.php
@@ -77,6 +77,8 @@ class AssertionFactory
     );
 
     /**
+     * The definition of the structure we are currently iterating through
+     *
      * @var StructureDefinitionInterface
      */
     protected $currentDefinition;
@@ -326,10 +328,12 @@ class AssertionFactory
                 }
                 // RawAssertion is sufficient
                 return new RawAssertion(array_pop($annotation->values));
+                break;
             case 'param':
             case 'return':
                 // simple assertions leave with a wide range of type assertions
                 return $this->createSimpleAssertion($annotation);
+                break;
             default:
                 break;
         }
@@ -342,9 +346,10 @@ class AssertionFactory
      * @return null|AssertionInterface
      * @throws \Exception
      */
-    public function createAssertion($assertionType, $constraint)
+    protected function createAssertion($assertionType, $constraint)
     {
-        if (null === ($assertionClassPath = $this->getAssertionClassPath($assertionType))) {
+        $assertionClassPath = $this->getAssertionClassPath($assertionType);
+        if (null === $assertionClassPath) {
             throw new \Exception(
                 sprintf(
                     'Cannot create complex assertion of type %s',
@@ -373,7 +378,7 @@ class AssertionFactory
      * @param string $assertionType the assertion type
      * @return null|string
      */
-    private function getAssertionClassPath($assertionType)
+    protected function getAssertionClassPath($assertionType)
     {
         if (class_exists($assertionType)) {
             return $assertionType;
@@ -403,7 +408,7 @@ class AssertionFactory
      * @param string $assertionType the assertion type
      * @return null|string
      */
-    private function resolveUsedAssertionStructure($assertionType)
+    protected function resolveUsedAssertionStructure($assertionType)
     {
         if (!$this->getCurrentDefinition()) {
             return null;

--- a/src/Entities/Assertions/AssertionFactory.php
+++ b/src/Entities/Assertions/AssertionFactory.php
@@ -338,7 +338,7 @@ class AssertionFactory
     /**
      * Tries to create assertion of $assertionType
      * @param string $assertionType the assertion type
-     * @param string $constraint the constraint to validate
+     * @param string $constraint    the constraint to validate
      * @return null|AssertionInterface
      * @throws \Exception
      */

--- a/src/Entities/Assertions/AssertionFactory.php
+++ b/src/Entities/Assertions/AssertionFactory.php
@@ -22,6 +22,7 @@ namespace AppserverIo\Doppelgaenger\Entities\Assertions;
 
 use AppserverIo\Doppelgaenger\Dictionaries\ReservedKeywords;
 use AppserverIo\Doppelgaenger\Entities\Lists\AssertionList;
+use AppserverIo\Doppelgaenger\Interfaces\StructureDefinitionInterface;
 use AppserverIo\Psr\MetaobjectProtocol\Dbc\Assertions\AssertionInterface;
 use AppserverIo\Psr\MetaobjectProtocol\Dbc\Annotations\Ensures;
 use AppserverIo\Psr\MetaobjectProtocol\Dbc\Annotations\Invariant;
@@ -74,6 +75,11 @@ class AssertionFactory
         'boolean',
         'void'
     );
+
+    /**
+     * @var StructureDefinitionInterface
+     */
+    protected $currentDefinition;
 
     /**
      * Parse assertions which are a collection of others
@@ -314,52 +320,102 @@ class AssertionFactory
             case Invariant::ANNOTATION:
             case Requires::ANNOTATION:
                 // complex annotations leave us with two possibilities: raw or custom assertions
-
                 if (isset($annotation->values['type'], $annotation->values['constraint'])) {
                     // we need a custom assertion here
-
-                    $potentialAssertion = $annotation->values['type'];
-                    if (class_exists($potentialAssertion)) {
-                        $assertionInstance = new $potentialAssertion($annotation->values['constraint']);
-                        if (!$assertionInstance instanceof AssertionInterface) {
-                            throw new \Exception(
-                                sprintf(
-                                    'Specified assertion of type %s does not implement %s',
-                                    $potentialAssertion,
-                                    AssertionInterface::class
-                                )
-                            );
-                        }
-                        return $assertionInstance;
-                    }
-
-                    $potentialAssertion = '\AppserverIo\Doppelgaenger\Entities\Assertions\\' . $annotation->values['type'] . 'Assertion';
-                    if (class_exists($potentialAssertion)) {
-                        // we know the class! Create an instance using the passed constraint
-                        /** @var \AppserverIo\Psr\MetaobjectProtocol\Dbc\Assertions\AssertionInterface $assertionInstance */
-                        $assertionInstance = new $potentialAssertion($annotation->values['constraint']);
-                        return $assertionInstance;
-
-                    } else {
-                        throw new \Exception(sprintf('Cannot create complex assertion of type %s', $annotation->values['type']));
-                    }
-
-                } else {
-                    // a RawAssertion is sufficient
-
-                    return new RawAssertion(array_pop($annotation->values));
+                    return $this->createAssertion($annotation->values['type'], $annotation->values['constraint']);
                 }
-                break;
-
+                // RawAssertion is sufficient
+                return new RawAssertion(array_pop($annotation->values));
             case 'param':
             case 'return':
                 // simple assertions leave with a wide range of type assertions
                 return $this->createSimpleAssertion($annotation);
-                break;
-
             default:
                 break;
         }
+    }
+
+    /**
+     * Tries to create assertion of $assertionType
+     * @param string $assertionType the assertion type
+     * @param string $constraint the constraint to validate
+     * @return null|AssertionInterface
+     * @throws \Exception
+     */
+    public function createAssertion($assertionType, $constraint)
+    {
+        if (null === ($assertionClassPath = $this->getAssertionClassPath($assertionType))) {
+            throw new \Exception(
+                sprintf(
+                    'Cannot create complex assertion of type %s',
+                    $assertionType
+                )
+            );
+        }
+
+        $potentialAssertion = new $assertionClassPath($constraint);
+        if (!$potentialAssertion instanceof AssertionInterface) {
+            throw new \Exception(
+                sprintf(
+                    'Specified assertion of type %s does not implement %s',
+                    $potentialAssertion,
+                    AssertionInterface::class
+                )
+            );
+        }
+
+        return $potentialAssertion;
+    }
+
+    /**
+     * Resolves and returns the fully qualified namespace of $assertionType
+     * or null if $assertionType cannot be resolved to an accessible class
+     * @param string $assertionType the assertion type
+     * @return null|string
+     */
+    private function getAssertionClassPath($assertionType)
+    {
+        if (class_exists($assertionType)) {
+            return $assertionType;
+        }
+
+        $potentialAssertion = $this->resolveUsedAssertionStructure($assertionType);
+        if (class_exists($potentialAssertion)) {
+            return $potentialAssertion;
+        }
+
+        $potentialAssertion = '\AppserverIo\Doppelgaenger\Entities\Assertions\\' . $assertionType;
+        if (class_exists($potentialAssertion)) {
+            return $potentialAssertion;
+        }
+
+        $potentialAssertion .= 'Assertion';
+        if (class_exists($potentialAssertion)) {
+            return $potentialAssertion;
+        }
+
+        return null;
+    }
+
+    /**
+     * Iterates through the 'use' operators of the current structure and
+     * returns the fully qualified namespace to the Assertion or null if none is found
+     * @param string $assertionType the assertion type
+     * @return null|string
+     */
+    private function resolveUsedAssertionStructure($assertionType)
+    {
+        if (!$this->getCurrentDefinition()) {
+            return null;
+        }
+
+        foreach ($this->getCurrentDefinition()->getUsedStructures() as $structure) {
+            if (preg_match('/\w+$/', $structure, $matches) && $matches[0] === $assertionType) {
+                return $structure;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -370,5 +426,22 @@ class AssertionFactory
     public function getValidScalarTypes()
     {
         return $this->validScalarTypes;
+    }
+
+    /**
+     * @param StructureDefinitionInterface $currentDefinition the definition of the current structure
+     * @return void
+     */
+    public function setCurrentDefinition(StructureDefinitionInterface $currentDefinition)
+    {
+        $this->currentDefinition = $currentDefinition;
+    }
+
+    /**
+     * @return null|StructureDefinitionInterface
+     */
+    public function getCurrentDefinition()
+    {
+        return $this->currentDefinition;
     }
 }

--- a/src/Parser/AnnotationParser.php
+++ b/src/Parser/AnnotationParser.php
@@ -326,6 +326,9 @@ class AnnotationParser extends AbstractParser
 
         // lets build up the result array
         $assertionFactory = new AssertionFactory();
+        if ($this->currentDefinition) {
+            $assertionFactory->setCurrentDefinition($this->currentDefinition);
+        }
         $result = new AssertionList();
         foreach ($annotations as $annotation) {
             // try to create assertion instances for all annotations


### PR DESCRIPTION
When using the @Requires annotation, it is no longer necessary to define the fully qualified class path as the type argument. Instead, you can just import the namespace and use the class name as the argument.

Before: 
```php
/**
 * @Requires(
 *     type="\MyVendor\MyProject\Entities\Assertions\RespectValidationAssertion",
 *     constraint=" ... "
 * )
 */
```

Now: 
```php
use MyVendor\MyProject\Entities\Assertions\RespectValidationAssertion

...

/**
 * @Requires(
 *     type="RespectValidationAssertion",
 *     constraint=" ... "
 * )
 */
```

This removes annoying redundancy.
Built-in assertions from AppserverIo/Doppelgaenger can still be used like before:
```php
/**
 * @Require(type="RespectValidation", constraint=" ... ")
 */
```

Utilizing the full class name "RespectValidationAssertion" is also working now.